### PR TITLE
remove confusing redundancy for IndexRoute

### DIFF
--- a/the-soundcloud-client-in-react-redux.md
+++ b/the-soundcloud-client-in-react-redux.md
@@ -1610,7 +1610,6 @@ ReactDOM.render(
     <Router history={history}>
       <Route path="/" component={App}>
         <IndexRoute component={Stream} />
-        <Route path="/" component={Stream} />
         <Route path="/callback" component={Callback} />
       </Route>
     </Router>

--- a/the-soundcloud-client-in-react-redux.md
+++ b/the-soundcloud-client-in-react-redux.md
@@ -1127,7 +1127,6 @@ ReactDOM.render(
     <Router history={history}>
       <Route path="/" component={App}>
         <IndexRoute component={Stream} />
-        <Route path="/" component={Stream} />
         <Route path="/callback" component={Callback} />
       </Route>
     </Router>


### PR DESCRIPTION
Note that following this tutorial is the first time I'm encountering react-router, so this could easily be totally wrong.

But, from what I'm reading in [the official react-router tutorial](https://github.com/reactjs/react-router-tutorial/tree/master/lessons/08-index-routes), it seems to me like:

```
      <Route path="/" component={App}>
        <IndexRoute component={Stream} />
```

and

```
      <Route path="/" component={App}> 
        <Route path="/" component={Stream} />
```

would both have the exact same effect, making:

```
      <Route path="/" component={App}>
        <IndexRoute component={Stream} />
        <Route path="/" component={Stream} />
```

redundant and confusing.

Please advise :|