### PR TITLE
Update guide to use corsOptions

### DIFF
--- a/react-express-stripe-payment.md
+++ b/react-express-stripe-payment.md
@@ -319,7 +319,7 @@ const corsOptions = {
 };
 
 const configureServer = app => {
-  app.use(cors());
+  app.use(cors(corsOptions));
 
   app.use(bodyParser.json());
 };


### PR DESCRIPTION
In `app.use(cors())` the previously defined `corsOptions` was forgotten, I have added it to allow cross origin requests in production.