### PR TITLE
Fix typo in react testing tutorial

### DIFF
--- a/react-testing-tutorial.md
+++ b/react-testing-tutorial.md
@@ -259,10 +259,10 @@ In the last step of this section, let's see how these three libraries are config
 {{< highlight javascript >}}
 mkdir test
 cd test
-touch helper.js dom.js
+touch helpers.js dom.js
 {{< /highlight >}}
 
-Both files will be filled with content now. Later on, they will be used as configuration to run the tests via a script on the command line. Let's go first with the *test/helper.js* file:
+Both files will be filled with content now. Later on, they will be used as configuration to run the tests via a script on the command line. Let's go first with the *test/helpers.js* file:
 
 {{< highlight javascript >}}
 import { expect } from 'chai';


### PR DESCRIPTION
This is a small typo I found when going through the tutorial: the helper file is first created as "helper.js", but referred to as "helper**s**.js" later in the tutorial.