### PR TITLE
Fix "Cannot read property 'email' of null"

### DIFF
--- a/complete-firebase-authentication-react-tutorial.md
+++ b/complete-firebase-authentication-react-tutorial.md
@@ -1561,7 +1561,7 @@ const AccountPage = () =>
   <AuthUserContext.Consumer>
     {authUser =>
       <div>
-        <h1>Account: {authUser.email}</h1>
+        <h1>Account: {authUser ? authUser.email : null}</h1>
         <PasswordForgetForm />
         <PasswordChangeForm />
       </div>


### PR DESCRIPTION
Without conditional rendering above mentioned error pops up. 
![screenshot from 2018-08-28 16-56-03](https://user-images.githubusercontent.com/40847850/44715975-5418a700-aae3-11e8-8ead-0f91fee31d42.png)

Check for null {console.log(authUser === null)} prints true first and false later every time you reload the page.
![screenshot from 2018-08-28 16-55-07](https://user-images.githubusercontent.com/40847850/44715991-5ed33c00-aae3-11e8-9f3f-68c789ed7f42.png)
