### PR TITLE
Remove premature reference to authUser.email

### DIFF
--- a/complete-firebase-authentication-react-tutorial.md
+++ b/complete-firebase-authentication-react-tutorial.md
@@ -1825,7 +1825,7 @@ import PasswordChangeForm from '../PasswordChange';
 
 const AccountPage = () => (
   <div>
-    <h1>Account: {authUser.email}</h1>
+    <h1>Account Page</h1>
     <PasswordForgetForm />
     <PasswordChangeForm />
   </div>


### PR DESCRIPTION
I don't think you meant to have {authUser.email} in Account/index.js at this point because it does not compile until later in the article where you introduce AuthUserContext.Consumer into Account/index.js. I think you meant to leave it as simply "Account Page" until that later bit where you add AuthUserContext.