### PR TITLE
Update graphql-apollo-client-tutorial links

### DIFF
--- a/blog/graphql-apollo-client-tutorial/index.md
+++ b/blog/graphql-apollo-client-tutorial/index.md
@@ -213,7 +213,7 @@ More meta information about the request can be found next to the `data` object. 
   * Get comfortable navigating through their documentation
   * Add other fields for the `organization` field
 * Read more about [why you should use Apollo Client](https://www.apollographql.com/docs/react/why-apollo.html)
-* Read more about the [networkStatus property and its possible values](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts)
+* Read more about the [networkStatus property and its possible values](https://www.apollographql.com/docs/react/api/react-hoc/#datanetworkstatus)
 * Invest 3 minutes of your time and take the [quiz](https://www.surveymonkey.com/r/5MF35H5)
 
 # Apollo Client with Pagination, Variables, Nested Objects and List Fields

--- a/blog/graphql-apollo-client-tutorial/index.md
+++ b/blog/graphql-apollo-client-tutorial/index.md
@@ -203,7 +203,7 @@ That's all there is to sending a query with the Apollo Client.  As noted, Apollo
 
 The requested information from the GraphQL query can be found in the `data` object. There, you will find the `organization` object with its `name` and `url` fields. The Apollo Client automatically requests the GraphQL [meta field](http://graphql.org/learn/queries/#meta-fields) `__typename`. The meta field can be used by the Apollo Client as an identifier, to allow caching and optimistic UI updates.
 
-More meta information about the request can be found next to the `data` object. It shows whether the data is still loading, as well as specific details about the [network status](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts), and whether the requested data is stale on the server-side.
+More meta information about the request can be found next to the `data` object. It shows whether the data is still loading, as well as specific details about the [network status](https://www.apollographql.com/docs/react/api/react-hoc/#datanetworkstatus), and whether the requested data is stale on the server-side.
 
 ### Exercises:
 


### PR DESCRIPTION
In graphql-apollo-client-tutorial, the link for "networkStatus property and its possible values" has been shifted to another link.
Updated link is: https://www.apollographql.com/docs/react/api/react-hoc/#datanetworkstatus