### PR TITLE
Corrected typo in the title (wit -> with)

### DIFF
--- a/blog/react-internationalization/index.md
+++ b/blog/react-internationalization/index.md
@@ -1,5 +1,5 @@
 ---
-title: "React Internationalization wit i18n"
+title: "React Internationalization with i18n"
 description: "A React tutorial about internationalization in React with i18n for translating texts to many languages for your React application ..."
 date: "2020-02-12T13:50:46+02:00"
 categories: ["React"]


### PR DESCRIPTION
The original title of this blog post is "React Internationalization wit i18n".
I changed it to "React Internationalization **with** i18n"
There was an h missing.