### PR TITLE
Switch line highlighting to HomeTabs component

### DIFF
--- a/blog/react-native-navigation/index.md
+++ b/blog/react-native-navigation/index.md
@@ -989,7 +989,7 @@ const HomeTabs = () => {
 
 Finally, use it in the Drawer Navigation. Instead of using the HomeScreen there, use the new HomeTabs (which in return use the Home screen now):
 
-```javascript{9}
+```javascript{8}
 ...
 
 const Drawer = createDrawerNavigator();


### PR DESCRIPTION
The `AccountScreen` component line is currently highlighted for the step that says to add the `HomeScreen` component. This change updates highlighted line number to the correct line.

![image](https://user-images.githubusercontent.com/24415914/99273586-38e6fe80-27f7-11eb-8eab-e2745a21ff40.png)
