### PR TITLE
Fixing uuid import and calls in  React State Hooks article

### DIFF
--- a/blog/react-state-usereducer-usestate-usecontext/index.md
+++ b/blog/react-state-usereducer-usestate-usecontext/index.md
@@ -228,21 +228,21 @@ Second, you can use it to generate a unique identifier:
 
 ```javascript{2,6,11,16,32}
 import React, { useState } from 'react';
-import uuid from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 const initialTodos = [
   {
-    id: uuid(),
+    id: uuidv4(),
     task: 'Learn React',
     complete: true,
   },
   {
-    id: uuid(),
+    id: uuidv4(),
     task: 'Learn Firebase',
     complete: true,
   },
   {
-    id: uuid(),
+    id: uuidv4(),
     task: 'Learn GraphQL',
     complete: false,
   },
@@ -258,7 +258,7 @@ const App = () => {
 
   const handleSubmit = event => {
     if (task) {
-      setTodos(todos.concat({ id: uuid(), task, complete: false }));
+      setTodos(todos.concat({ id: uuidv4(), task, complete: false }));
     }
 
     setTask('');

--- a/blog/react-state-usereducer-usestate-usecontext/index.md
+++ b/blog/react-state-usereducer-usestate-usecontext/index.md
@@ -672,7 +672,7 @@ const App = () => {
 
   const handleSubmit = event => {
     if (task) {
-      dispatchTodos({ type: 'ADD_TODO', task, id: uuid() });
+      dispatchTodos({ type: 'ADD_TODO', task, id: uuidv4() });
     }
 
     setTask('');
@@ -817,7 +817,7 @@ const AddTodo = ({ dispatch }) => {
 
   const handleSubmit = event => {
     if (task) {
-      dispatch({ type: 'ADD_TODO', task, id: uuid() });
+      dispatch({ type: 'ADD_TODO', task, id: uuidv4() });
     }
 
     setTask('');
@@ -910,7 +910,7 @@ const AddTodo = () => {
 
   const handleSubmit = event => {
     if (task) {
-      dispatch({ type: 'ADD_TODO', task, id: uuid() });
+      dispatch({ type: 'ADD_TODO', task, id: uuidv4() });
     }
 
     setTask('');


### PR DESCRIPTION
It seems like UUID changed the way to import and call the library: https://www.npmjs.com/package/uuid

This results in a compile error if you use the legacy import/call.

The changes here update both.