### PR TITLE
Correct English language and add Part numbers

### DIFF
--- a/blog/react-table-component/index.md
+++ b/blog/react-table-component/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to create a React Table Component"
+title: "Part 1 &ndash; How to create a React Table Component"
 description: "A step by step tutorial on how to create a React table component with React Table Library ..."
 date: "2021-05-17T13:56:46+02:00"
 categories: ["React", "React Table Library"]
@@ -12,15 +12,15 @@ author: ""
 
 <Sponsorship />
 
-In this tutorial, I want to show you how to use [React Table Library](https://react-table-library.com) for **creating a table component in React**. After this tutorial, there will be many other examples which you can continue to build, such as [searching](/react-table-search/), [filtering](/react-table-filter/), [sorting](/react-table-sort/), [selecting](/react-table-select/), nesting [tree tables](/react-tree-table/), or [pagination](/react-table-pagination/) features for your React table by using the library's documentation. But let's start with the basics.
+In this tutorial, I want to show you how to use [React Table Library](https://react-table-library.com) to **create a table component in React**. After this part, there are many other parts giving you examples for [searching](/react-table-search/), [filtering](/react-table-filter/), [sorting](/react-table-sort/), [selecting](/react-table-select/), nesting [tree tables](/react-tree-table/), and [pagination](/react-table-pagination/) for your React table by using React Table Library. Let's start with the basics.
 
-Let's begin by installing React Table Library via your command line:
+First, install React Table Library from the command line:
 
 ```javascript
 npm install @table-library/react-table-library @emotion/react
 ```
 
-The task is to present the following list of items in a React table component:
+We are going to present the following list of items in a React table component:
 
 ```javascript
 const list = [
@@ -48,7 +48,7 @@ const list = [
 ];
 ```
 
-We will start with structuring the list in an object which can be consumed by the Table component. The component itself gets imported from the library:
+Next, the list is wrapped by an object which can be consumed by the Table component. The component itself is imported from the library:
 
 ```javascript{2,7,9}
 import * as React from 'react';
@@ -63,9 +63,9 @@ const App = () => {
 };
 ```
 
-The Table component accepts a data object as [prop](/react-pass-props-to-component/) with a `nodes` property. These nodes are the items in our lists, however, the table keeps it more generic to the naming of `nodes`, because the table can not only display list structures but also [tree structures](/react-tree-table/).
+The Table component accepts a data object as a [prop](/react-pass-props-to-component/) with a `nodes` property. These nodes are the items in our list, however, the table keeps the naming of `nodes` more generic, because the Table component has the ability not only to display list structures but also [tree structures](/react-tree-table/).
 
-Moreover, the Table component uses a [function as a children](/react-render-props/) which gives us access to our list within the table as `tableList`. Internally the Table component applies all sorts of modifications onto our list -- e.g. sorting, pagination and so on, if these plugins are enabled -- and thus the `tableList` (and not `data` or `list`) should be used to render the items within the table.
+Moreover, the Table component uses a [function as a child](/react-render-props/) giving access to the list within the table as `tableList`. Internally, the Table component applies many different modifications to the list &ndash; e.g. sorting, pagination, if these plugins are enabled &ndash; and so the `tableList` (and not `data` or `list`) should be used to render the items within the table.
 
 React Table Library uses [composition over configuration](/react-component-composition/). Therefore, you get all the necessary building blocks as components from the library itself. Let's begin with the header of our table:
 
@@ -100,9 +100,9 @@ const App = () => {
 };
 ```
 
-By using these components, you can create a table as a composition from components whereas each component has its own responsibility. For example, instead of having only one Table component which accepts one large configuration object, we have composable components -- such as Header, HeaderRow, and HeaderCell, which can receive dedicated props.
+By using these components, you can create a table as a composition from components where each component has its own responsibility. For example, instead of having only one Table component which accepts one large configuration object, there are several composable components, such as Header, HeaderRow, and HeaderCell, which can all receive dedicated props.
 
-Next, let's display our items like we are used to when [rendering lists in React](/react-list-component/) by rendering Row components with a [key](/react-list-key/) for each item within a Body component:
+Finally, let's display the items in the usual way when [rendering lists in React](/react-list-component/) by rendering Row components with a [key](/react-list-key/) for each item within a Body component:
 
 ```javascript{7-9,20,25-43,44}
 import * as React from 'react';
@@ -155,16 +155,16 @@ const App = () => {
 };
 ```
 
-Since you have full control over what to render in the Cell components, you can format the data as you need to. A boolean can be translated into a string and a date can be formatted to a readable version. There are no special props for the Cell components to get the rendering done. Using [React Table Library](https://react-table-library.com) makes it straightforward to render table components in React. Head over to the library's documentation to find out more about it and its features.
+As you have full control over what to render in the Cell components, you can format the data as you need to. A boolean can be translated into a string and a date can be formatted to a readable version. There are no special props for the Cell components to do rendering. Using [React Table Library](https://react-table-library.com) makes it easy to render Table components in React. Go to the library's documentation to find out more about its features.
 
-- [React Table with Theme](/react-table-theme/)
-- [React Table with Resize](/react-table-resize/)
-- [React Table with Sort](/react-table-sort/)
-- [React Table with Search](/react-table-search/)
-- [React Table with Filter](/react-table-filter/)
-- [React Table with Select](/react-table-select/)
-- [React Table with Tree](/react-tree-table/)
-- [React Table with Fixed Header](/react-table-fixed-header/)
-- [React Table with Fixed Column](/react-table-fixed-column/)
-- [React Table with Pagination](/react-table-pagination/)
-- [React Table with Server-Side Operations](/react-server-side-table/)
+- [Part 2 &ndash; React Table with Theme](/react-table-theme/)
+- [Part 3 &ndash; React Table with Resize](/react-table-resize/)
+- [Part 4 &ndash; React Table with Sort](/react-table-sort/)
+- [Part 5 &ndash; React Table with Search](/react-table-search/)
+- [Part 6 &ndash; React Table with Filter](/react-table-filter/)
+- [Part 7 &ndash; React Table with Select](/react-table-select/)
+- [Part 8 &ndash; React Table with Tree](/react-tree-table/)
+- [Part 9 &ndash; React Table with Fixed Header](/react-table-fixed-header/)
+- [Part 10 &ndash; React Table with Fixed Column](/react-table-fixed-column/)
+- [Part 11 &ndash; React Table with Pagination](/react-table-pagination/)
+- [Part 12 &ndash; React Table with Server-Side Operations](/react-server-side-table/)

--- a/blog/react-table-component/index.md
+++ b/blog/react-table-component/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Part 1 &ndash; How to create a React Table Component"
+title: "How to create a React Table Component"
 description: "A step by step tutorial on how to create a React table component with React Table Library ..."
 date: "2021-05-17T13:56:46+02:00"
 categories: ["React", "React Table Library"]
@@ -65,7 +65,7 @@ const App = () => {
 
 The Table component accepts a data object as a [prop](/react-pass-props-to-component/) with a `nodes` property. These nodes are the items in our list, however, the table keeps the naming of `nodes` more generic, because the Table component has the ability not only to display list structures but also [tree structures](/react-tree-table/).
 
-Moreover, the Table component uses a [function as a child](/react-render-props/) giving access to the list within the table as `tableList`. Internally, the Table component applies many different modifications to the list &ndash; e.g. sorting, pagination, if these plugins are enabled &ndash; and so the `tableList` (and not `data` or `list`) should be used to render the items within the table.
+Moreover, the Table component uses a [function as a child](/react-render-props/) giving access to the list within the table as `tableList`. Internally, the Table component applies many different modifications to the list -- e.g. sorting, pagination, if these plugins are enabled -- and so the `tableList` (and not `data` or `list`) should be used to render the items within the table.
 
 React Table Library uses [composition over configuration](/react-component-composition/). Therefore, you get all the necessary building blocks as components from the library itself. Let's begin with the header of our table:
 
@@ -157,14 +157,14 @@ const App = () => {
 
 As you have full control over what to render in the Cell components, you can format the data as you need to. A boolean can be translated into a string and a date can be formatted to a readable version. There are no special props for the Cell components to do rendering. Using [React Table Library](https://react-table-library.com) makes it easy to render Table components in React. Go to the library's documentation to find out more about its features.
 
-- [Part 2 &ndash; React Table with Theme](/react-table-theme/)
-- [Part 3 &ndash; React Table with Resize](/react-table-resize/)
-- [Part 4 &ndash; React Table with Sort](/react-table-sort/)
-- [Part 5 &ndash; React Table with Search](/react-table-search/)
-- [Part 6 &ndash; React Table with Filter](/react-table-filter/)
-- [Part 7 &ndash; React Table with Select](/react-table-select/)
-- [Part 8 &ndash; React Table with Tree](/react-tree-table/)
-- [Part 9 &ndash; React Table with Fixed Header](/react-table-fixed-header/)
-- [Part 10 &ndash; React Table with Fixed Column](/react-table-fixed-column/)
-- [Part 11 &ndash; React Table with Pagination](/react-table-pagination/)
-- [Part 12 &ndash; React Table with Server-Side Operations](/react-server-side-table/)
+- [React Table with Theme](/react-table-theme/)
+- [React Table with Resize](/react-table-resize/)
+- [React Table with Sort](/react-table-sort/)
+- [React Table with Search](/react-table-search/)
+- [React Table with Filter](/react-table-filter/)
+- [React Table with Select](/react-table-select/)
+- [React Table with Tree](/react-tree-table/)
+- [React Table with Fixed Header](/react-table-fixed-header/)
+- [React Table with Fixed Column](/react-table-fixed-column/)
+- [React Table with Pagination](/react-table-pagination/)
+- [React Table with Server-Side Operations](/react-server-side-table/)


### PR DESCRIPTION
Corrected some minor grammar errors.
Improved the style.
Removed some less common wording.
Simplified the style.
Added Part 1 to the title
Added part numbers to the links at the bottom -- the actual parts themselves are not numbered elsewhere, but if this proposal is accepted then I will number the other parts accordingly
I corrected  "uses a [function as a child]" but it could also be "uses [functions as children]". At this moment, I am not sure which is better in this context.