### PR TITLE
Fix list object name/Add more items to data list

### DIFF
--- a/blog/react-table-fixed-header/index.md
+++ b/blog/react-table-fixed-header/index.md
@@ -28,14 +28,14 @@ author: ""
   ]}
 />
 
-In this tutorial, I want to show you how to use [React Table Library](https://react-table-library.com) with a **fixed header**. In the previous example, you installed React Table Library to create a Table component and gave it a theme. Now, we will enable users to have their **header sticky** to the top:
+In this tutorial, I want to show you how to use [React Table Library](https://react-table-library.com) with a **fixed header**. In the previous example, you installed React Table Library to create a table component and gave it a theme. Now, we will enable users to have their **header sticky** to the top:
 
 ```javascript{2,7-11,14-18,19,22}
 ...
 import { useTheme } from '@table-library/react-table-library/theme';
 
 const App = () => {
-  const data = { nodes };
+  const data = { nodes: list };
 
   const theme = useTheme({
     Table: `
@@ -55,6 +55,83 @@ const App = () => {
     </div>
   );
 };
+```
+
+The data object we passed to the Table component in the previous tutorial only had three items, so we need to use a different data object this time with more items in order to see the sticky header work properly. The following data object has ten items and works properly.
+
+```javascript
+const list = [
+  {
+    id: "1",
+    name: "VSCode",
+    deadline: new Date(2020, 1, 17),
+    type: "SETUP",
+    isComplete: true,
+  },
+  {
+    id: "2",
+    name: "JavaScript",
+    deadline: new Date(2020, 2, 28),
+    type: "LEARN",
+    isComplete: true,
+  },
+  {
+    id: "3",
+    name: "React",
+    deadline: new Date(2020, 3, 8),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "4",
+    name: "JSX",
+    deadline: new Date(2020, 4, 10),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "5",
+    name: "Hooks",
+    deadline: new Date(2020, 5, 12),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "6",
+    name: "Components",
+    deadline: new Date(2020, 6, 14),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "7",
+    name: "HTML",
+    deadline: new Date(2020, 7, 17),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "8",
+    name: "CSS",
+    deadline: new Date(2020, 8, 28),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "9",
+    name: "Classes",
+    deadline: new Date(2020, 9, 18),
+    type: "LEARN",
+    isComplete: false,
+  },
+  {
+    id: "10",
+    name: "Functions",
+    deadline: new Date(2020, 10, 5),
+    type: "LEARN",
+    isComplete: false,
+  },
+];
 ```
 
 As you can see, all that's needed for a fixed table header is a container component around the Table component. You can now scroll the rows of the table in a vertical direction while the header remains sticky at the top of the table.


### PR DESCRIPTION
With only three items in the list the sticky header was not visible.
The solution is to either adjust the styling, to say 'height: "50px"' or add more items. Adding more items to the data object makes a better example, probably.