### PR TITLE
Fix incorrect type

### DIFF
--- a/blog/typescript-react-useref/index.md
+++ b/blog/typescript-react-useref/index.md
@@ -156,7 +156,7 @@ function App() {
   const [seconds, setSeconds] = React.useState<number>(0);
   const [toggle, setToggle] = React.useState<boolean>(false);
 
-  const ref = React.useRef<NodeJS.Timeout | null>(null);
+  const ref = React.useRef<number | null>(null);
 
   const toggleStopwatch = () => {
     setToggle(!toggle);


### PR DESCRIPTION
Since useEffect is always executed from client side and what window.setInterval returns is intervalID(numeric, non-zero value), I guess It should be typed as a number