### PR TITLE
Added callback to the useEffect dependency array

### DIFF
--- a/blog/react-hook-detect-click-outside-component/index.md
+++ b/blog/react-hook-detect-click-outside-component/index.md
@@ -150,7 +150,7 @@ const useOutsideClick = (callback) => {
     return () => {
       document.removeEventListener('click', handleClick);
     };
-  }, [ref]);
+  }, [ref, callback]);
 
   return ref;
 };
@@ -228,7 +228,7 @@ const useOutsideClick = (callback) => {
     return () => {
       document.removeEventListener('click', handleClick, true);
     };
-  }, [ref]);
+  }, [ref, callback]);
 
   return ref;
 };


### PR DESCRIPTION
Encountered a bug when I used the useOutsideClick hook. The state inside the callback doesn't update. Can introduce unpredictable bugs if you're checking the state inside the callback. Added the callback to the useEffect dependency array so the callback closure updates and you don't run a stale version of the function. 


![Screenshot 2023-02-01 at 14 31 39](https://user-images.githubusercontent.com/33156891/216062432-d0d71784-ca2d-4c8d-93dc-4b12b4ed075d.png)
![Screenshot 2023-02-01 at 14 32 53](https://user-images.githubusercontent.com/33156891/216062453-334b4db0-b30f-4039-9756-dfed5c39f664.png)

Can test with this and adding/removing callback from the useEffect dependency array inside useOutsideClick.

```
const [outsideClicks, setOutsideClicks] = useState(0)

const handleOutsideClick = () => {
    console.log('With/without callback in dependecy array', outsideClicks)
    setOutsideClicks(outsideClicks + 1)
}

const ref = useOutsideClick(handleOutsideClick);
```