### PR TITLE
Vitest with React Testing Library: Fix matchers import

### DIFF
--- a/blog/vitest-react-testing-library/index.md
+++ b/blog/vitest-react-testing-library/index.md
@@ -87,7 +87,7 @@ Fourth, add a test setup file in *tests/setup.js* and give it the following impl
 ```javascript
 import { expect, afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
-import matchers from '@testing-library/jest-dom/matchers';
+import * as matchers from '@testing-library/jest-dom/matchers';
 
 // extends Vitest's expect method with methods from react-testing-library
 expect.extend(matchers);


### PR DESCRIPTION
The import of matchers is broken and results in the following error when trying to run the tests:
`TypeError: Cannot convert undefined or null to object`

To resolve this issue, it needs to be converted to a namespace import.