### PR TITLE
Fixed doGetUser example function name

### DIFF
--- a/blog/javascript-fake-api/index.md
+++ b/blog/javascript-fake-api/index.md
@@ -191,7 +191,7 @@ const getUser = (id) =>
   });
 
 // usage
-const doGetUsers = async (id) => {
+const doGetUser = async (id) => {
   try {
     const result = await getUser(id);
     console.log(result);
@@ -200,7 +200,7 @@ const doGetUsers = async (id) => {
   }
 };
 
-doGetUsers('1');
+doGetUser('1');
 ```
 
 Next, creating an item. If not all information is provided for the new item, the API will throw an error. Otherwise a new identifier for the item is generated and used to store the new item in the pseudo database:


### PR DESCRIPTION
In the "JavaScript Fake REST API" example for the singular "getUser", the function to make use of it is called "doGetUsers", plural, even though it takes an id and returns one user.

Changed the plurality to match the function it's invoking to avoid confusion.