### PR TITLE
import defineConfig from vitest/config

### DIFF
--- a/blog/vitest-react-testing-library/index.md
+++ b/blog/vitest-react-testing-library/index.md
@@ -64,7 +64,7 @@ npm install jsdom --save-dev
 Second, include it to the Vite configuration file:
 
 ```javascript{7-9}
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
@@ -99,7 +99,7 @@ afterEach(() => {
 And last, include this new test setup file in Vite's configuration file. In addition, make all imports from Vitest global, so that you don't need to perform these imports (e.g. `expect`) in each file manually anymore:
 
 ```javascript{8,10}
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
The defineConfig function from vite is not type aware of the 'test' parameter. Importing defineConfig from 'vitest/config' fixes.