### PR TITLE
feat: add `jsx-email` as a react library option for emails

### DIFF
--- a/blog/react-libraries/index.md
+++ b/blog/react-libraries/index.md
@@ -436,6 +436,7 @@ E-Mail rendering is a pain if you are just using HTML. Fortunately, there are li
 * [react-email](https://react.email/) (recommendation)
 * [mjml](https://mjml.io/)
 * [Mailing](https://www.mailing.run/)
+* [jsx-email](https://jsx.email/)
 
 If you are looking for a email service provider, check out [Resend](https://resend.com/), [Postmark](https://postmarkapp.com/), [SendGrid](https://sendgrid.com/), or [Mailgun](https://www.mailgun.com/).
 


### PR DESCRIPTION
Great article as usual! 🧑‍🍳

Noticed that 'react-email' was noted and recommended but wanted to also add to the list [jsx-email](https://jsx.email/) which is essentially the same thing but with no vendor lock-in for any of their components/tools in the library. Both are great and I use both but been leaning to jsx-email a lot more recently and can easily be interchanged.